### PR TITLE
fix: Adding audio support

### DIFF
--- a/src/repo_seed/buildspec.yml
+++ b/src/repo_seed/buildspec.yml
@@ -46,7 +46,8 @@ phases:
         pushd device/generic/goldfish/audio && 
         sed "303 i     case xsd::AudioDevice::AUDIO_DEVICE_OUT_BUS:" device_port_sink.cpp > device_port_sink.cpp.1 &&
         sed "317 d" device_port_sink.cpp.1 > device_port_sink.cpp.2 &&
-        cp device_port_sink.cpp.2 device_port_sink.cpp
+        cp device_port_sink.cpp.2 device_port_sink.cpp &&
+        popd
       - source build/envsetup.sh && lunch $TARGET_PRODUCT-$TARGET_BUILD_VARIANT && m -j $(nproc) dist
       - aws s3 cp out/dist/cvd-host_package.tar.gz s3://$BUCKET_NAME/
       - aws s3 cp out/dist/$TARGET_PRODUCT-img-eng.root.zip s3://$BUCKET_NAME/images.zip

--- a/src/repo_seed/buildspec.yml
+++ b/src/repo_seed/buildspec.yml
@@ -42,6 +42,11 @@ phases:
         cp launch_streamer.cpp.patch host/commands/run_cvd/launch_streamer.cpp && 
         cat  host/commands/run_cvd/launch_streamer.cpp && 
         popd
+      - >-
+        pushd device/generic/goldfish/audio && 
+        sed "303 i     case xsd::AudioDevice::AUDIO_DEVICE_OUT_BUS:" device_port_sink.cpp > device_port_sink.cpp.1 &&
+        sed "317 d" device_port_sink.cpp.1 > device_port_sink.cpp.2 &&
+        cp device_port_sink.cpp.2 device_port_sink.cpp
       - source build/envsetup.sh && lunch $TARGET_PRODUCT-$TARGET_BUILD_VARIANT && m -j $(nproc) dist
       - aws s3 cp out/dist/cvd-host_package.tar.gz s3://$BUCKET_NAME/
       - aws s3 cp out/dist/$TARGET_PRODUCT-img-eng.root.zip s3://$BUCKET_NAME/images.zip


### PR DESCRIPTION
Cuttlefish on Android-12 is using the audio HAL from goldfish. The audio HAL for goldfish doesn't support AUDIO_DEVICE_OUT_BUS as an audio device. Android Automotive variant needs the primary output device to be AUDIO_DEVICE_OUT_BUS , which is what is used in the Cuttlefish Auto on Android-12. So enabling the AUDIO_DEVICE_OUT_BUS on goldfish audio HAL.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
